### PR TITLE
Fix copyright symbol

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@
 							</div><!-- end of col-460 fit -->
 						</div>
 						<div class="row-fluid">
-							<div class="span5 copyright"> � 2013 | OGC IoT RESTful API </div> <!-- end copyright -->
+							<div class="span5 copyright"> &copy; 2013 | OGC IoT RESTful API </div> <!-- end copyright -->
 							<div class="span5 powered"></div><!-- end .powered -->
 						</div>
 					</div><!-- end of row -->


### PR DESCRIPTION
In the footnote, the HTML code for copyright symbol should be "& copy;" or "& #169;".
